### PR TITLE
Improve message forwarding logs

### DIFF
--- a/mtg/bot/telegram/telegram.py
+++ b/mtg/bot/telegram/telegram.py
@@ -223,6 +223,7 @@ class TelegramBot:  # pylint:disable=too-many-public-methods
             addressee = message.split(' ', maxsplit=1)[0].lstrip('APRS-').rstrip(':')
             msg = message.replace(message.split(' ', maxsplit=1)[0], '').strip()
             self.aprs.send_text(addressee, f'{full_user}: {msg}')
+        self.logger.info("Forwarding to mesh: %s", f"{full_user}: {message}")
         self.meshtastic_connection.send_text(f"{full_user}: {message}")
 
     def shorten_tly(self, long_url):

--- a/mtg/connection/meshtastic/meshtastic.py
+++ b/mtg/connection/meshtastic/meshtastic.py
@@ -83,6 +83,7 @@ class MeshtasticConnection:
         :param kwargs:
         :return:
         """
+        self.logger.debug("Sending to mesh: %s %s", msg, kwargs)
         if len(msg) < mesh_pb2.Constants.DATA_PAYLOAD_LEN // 2:  # pylint:disable=no-member
             with self.lock:
                 self.interface.sendText(msg, **kwargs)


### PR DESCRIPTION
## Summary
- add log when forwarding Telegram message to mesh
- log outbound messages inside `MeshtasticConnection.send_text`

## Testing
- `make check` *(fails: pylint missing)*
- `pytest -q` *(fails: command not found)*