### PR TITLE
Improve telegram chat check logs and library version enforcement

### DIFF
--- a/mtg/bot/telegram/telegram.py
+++ b/mtg/bot/telegram/telegram.py
@@ -181,10 +181,13 @@ class TelegramBot:  # pylint:disable=too-many-public-methods
         :param _:
         :return:
         """
-        if update.effective_chat.id != self.config.enforce_type(int, self.config.Telegram.Room):
-            self.logger.debug("%d %s",
-                              update.effective_chat.id,
-                              self.config.enforce_type(int, self.config.Telegram.Room))
+        room_id = self.config.enforce_type(int, self.config.Telegram.Room)
+        if update.effective_chat.id != room_id:
+            self.logger.warning(
+                "Ignoring message from chat %d; configured chat is %d", 
+                update.effective_chat.id,
+                room_id,
+            )
             return
         if self.filter.banned(str(update.effective_user.id)):
             self.logger.debug(f"User {update.effective_user.id} is in a blacklist...")

--- a/mtg/connection/telegram/telegram.py
+++ b/mtg/connection/telegram/telegram.py
@@ -6,6 +6,7 @@ import logging
 import time
 
 import telegram
+from pkg_resources import parse_version
 from telegram.error import NetworkError, TelegramError
 from telegram.ext import Updater
 # pylint:disable=no-name-in-module
@@ -20,6 +21,11 @@ class TelegramConnection:
     def __init__(self, token: str, logger: logging.Logger):
         self.logger = logger
         self.token = token
+        if parse_version(telegram.__version__) < parse_version("13.15"):
+            raise RuntimeError(
+                f"Unsupported python-telegram-bot version {telegram.__version__}; "
+                "please install 13.15"
+            )
         self.updater = Updater(token=token, use_context=True)
         self.exit = False
         self.name = 'Telegram Connection'


### PR DESCRIPTION
## Summary
- improve logging for messages coming from unexpected Telegram chats
- enforce required python-telegram-bot version during Telegram connection init

## Testing
- `pytest -q`
- `make lint`