### PR TITLE
Fix Telegram message forwarding

### DIFF
--- a/mtg/bot/telegram/telegram.py
+++ b/mtg/bot/telegram/telegram.py
@@ -108,7 +108,7 @@ class TelegramBot:  # pylint:disable=too-many-public-methods
         dispatcher.add_handler(log_handler, group=0)
 
         echo_handler = MessageHandler(~Filters.command, self.echo)
-        dispatcher.add_handler(echo_handler)
+        dispatcher.add_handler(echo_handler, group=1)
 
 
     def set_aprs(self, aprs):


### PR DESCRIPTION
## Summary
- ensure Telegram echo handler is executed after logging

## Testing
- `make lint`
- `make mypy` *(fails: "Found 118 errors in 10 files")*
- `make test`