### PR TITLE
Improve message splitting with sender

### DIFF
--- a/mtg/bot/telegram/telegram.py
+++ b/mtg/bot/telegram/telegram.py
@@ -257,7 +257,7 @@ class TelegramBot:  # pylint:disable=too-many-public-methods
             "message_id": update.message.message_id if update.message else None,
         }
         self.logger.info(json.dumps(log_data))
-        self.meshtastic_connection.send_text(f"{full_user}: {message}")
+        self.meshtastic_connection.send_user_text(full_user, message)
 
     def shorten_tly(self, long_url):
         """

--- a/mtg/utils/__init__.py
+++ b/mtg/utils/__init__.py
@@ -5,5 +5,5 @@ from .exc import log_exception
 from .fifo import create_fifo
 from .imp import list_classes
 from .memcache import Memcache
-from .message import split_message
+from .message import split_message, split_user_message
 from .external import ExternalPlugins

--- a/mtg/utils/message.py
+++ b/mtg/utils/message.py
@@ -2,6 +2,9 @@
 """ message utilities """
 
 
+import textwrap
+
+
 def split_message(msg, chunk_len, callback, **kwargs) -> None:
     """
     split_message - split message into smaller parts and invoke callback on each one
@@ -31,3 +34,26 @@ def split_message(msg, chunk_len, callback, **kwargs) -> None:
         else:
             for i in range((len(line) // chunk_len) + 1):
                 callback(line[i*chunk_len:i*chunk_len + chunk_len], **kwargs)
+
+
+def split_user_message(sender: str, msg: str, chunk_len: int):
+    """Split user's message into chunks with sender prefix and counters"""
+
+    prefix = f"{sender}: "
+    # initial assumption about parts
+    parts_count = 1
+    while True:
+        counter = f"[{parts_count}/{parts_count}] "
+        available = chunk_len - len(prefix) - len(counter)
+        wrapper = textwrap.TextWrapper(
+            width=available,
+            break_long_words=False,
+            break_on_hyphens=False,
+            replace_whitespace=False,
+        )
+        parts = [p.strip() for p in wrapper.wrap(msg) if p.strip()]
+        if len(parts) == parts_count:
+            break
+        parts_count = len(parts)
+
+    return [f"{prefix}[{idx}/{parts_count}] {part}" for idx, part in enumerate(parts, start=1)]


### PR DESCRIPTION
## Summary
- add `split_user_message` to intelligently break messages into chunks
- export new helper
- support sending user-prefixed multi-part messages in Meshtastic connection
- use new method from Telegram bot

## Testing
- `make check` *(fails: pylint error code 10)*
- `make test`