### PR TITLE
Organize device reset configuration

### DIFF
--- a/mesh.ini.example
+++ b/mesh.ini.example
@@ -114,6 +114,27 @@ WelcomeMessage = Welcome to our community
 WelcomeMessageEnabled = false
 MaxHopCount = 5
 
+[MeshtasticReset]
+# Automatically enforce selected device parameters on startup. Boolean.
+# Enabling this may reboot the device while settings are applied.
+Enabled = false
+# Use Telegram room link as long name if true.
+LongNameFromRoomLink = true
+# Optional long name override when not using the room link. String.
+LongName =
+# Short name for the device (4 bytes max). String.
+ShortName = 🔗
+# Hop count for LoRa config. Integer.
+HopLimit = 5
+# Region code for LoRa config. String (US, EU_433, EU_868, etc.).
+Region = EU_868
+# Override LoRa duty cycle restrictions. Boolean.
+DutyCycle = true
+# Device role. String (ROUTER_LATE, CLIENT, etc.).
+Role = ROUTER_LATE
+# Allow sharing location over MQTT public maps. Boolean.
+MapReporting = true
+
 [APRS]
 # en: APRS functionality. Not actually used. Boolean.
 # pl: Funkcjonalność APRS. Właściwie nie używany. Logiczne.

--- a/mesh.py
+++ b/mesh.py
@@ -77,6 +77,7 @@ def main(args):
                                            database, rg_fn=rg.search)
     database.set_meshtastic(meshtastic_connection)
     meshtastic_connection.connect()
+    meshtastic_connection.reset_params()
     #
     mqtt_connection = MQTT(config.MQTT.Topic, config.MQTT.Host, config.MQTT.User, config.MQTT.Password,
                            logger, config.enforce_type(int, config.MQTT.Port))

--- a/mtg/connection/meshtastic/meshtastic.py
+++ b/mtg/connection/meshtastic/meshtastic.py
@@ -21,6 +21,8 @@ from meshtastic import (
     mesh_pb2
 )
 # pylint:disable=no-name-in-module
+from meshtastic.protobuf import config_pb2
+# pylint:disable=no-name-in-module,no-member
 from setproctitle import setthreadtitle
 
 from mtg.utils import create_fifo, split_message, split_user_message
@@ -170,6 +172,112 @@ class MeshtasticConnection:
         self.logger.info('Reset node DB requested...')
         self.interface.getNode(MESHTASTIC_LOCAL_ADDR).resetNodeDb()
         self.logger.info('Reset node DB completed...')
+
+    # pylint:disable=too-many-locals,too-many-branches,too-many-statements
+    def reset_params(self):
+        """Reset device parameters to configured values.
+
+        The device reboots after configuration is applied, which is expected.
+        """
+        if not self.config.enforce_type(
+            bool, getattr(self.config.MeshtasticReset, 'Enabled', 'false')
+        ):
+            return
+        try:
+            self.interface.waitForConfig()
+        except Exception as exc:  # pylint:disable=broad-except
+            self.logger.error('Could not fetch device config: %s', repr(exc))
+            return
+
+        node = self.interface.getNode(MESHTASTIC_LOCAL_ADDR)
+        diffs = []
+
+        use_room = self.config.enforce_type(
+            bool,
+            getattr(self.config.MeshtasticReset, 'LongNameFromRoomLink', 'true'),
+        )
+        desired_long = (
+            self.config.Telegram.RoomLink
+            if use_room
+            else getattr(self.config.MeshtasticReset, 'LongName', None)
+        )
+        desired_short = getattr(self.config.MeshtasticReset, 'ShortName', '🔗')
+        current_long = self.interface.getLongName() or ''
+        current_short = self.interface.getShortName() or ''
+        if (desired_long and desired_long != current_long) or (
+            desired_short and desired_short != current_short
+        ):
+            diffs.append(
+                f'name {current_long}/{current_short} -> {desired_long}/{desired_short}'
+            )
+            node.setOwner(long_name=desired_long, short_name=desired_short)
+
+        lora = node.localConfig.lora
+        lora_changed = False
+        if hasattr(self.config.MeshtasticReset, 'HopLimit'):
+            hop_limit = self.config.enforce_type(
+                int, self.config.MeshtasticReset.HopLimit
+            )
+            if lora.hop_limit != hop_limit:
+                diffs.append(f'hop_limit {lora.hop_limit}->{hop_limit}')
+                lora.hop_limit = hop_limit
+                lora_changed = True
+        if hasattr(self.config.MeshtasticReset, 'Region'):
+            try:
+                region_enum = config_pb2.Config.LoRaConfig.RegionCode.Value(
+                    self.config.MeshtasticReset.Region
+                )
+                if lora.region != region_enum:
+                    diffs.append(
+                        f'region {lora.region}->{self.config.MeshtasticReset.Region}'
+                    )
+                    lora.region = region_enum
+                    lora_changed = True
+            except Exception as exc:  # pylint:disable=broad-except
+                self.logger.error('Invalid region %s: %s', self.config.MeshtasticReset.Region, repr(exc))
+        if hasattr(self.config.MeshtasticReset, 'DutyCycle'):
+            duty = self.config.enforce_type(
+                bool, self.config.MeshtasticReset.DutyCycle
+            )
+            if lora.override_duty_cycle != duty:
+                diffs.append(f'duty_cycle {lora.override_duty_cycle}->{duty}')
+                lora.override_duty_cycle = duty
+                lora_changed = True
+        if lora_changed:
+            node.writeConfig('lora')
+
+        if hasattr(self.config.MeshtasticReset, 'Role'):
+            try:
+                role_enum = config_pb2.Config.DeviceConfig.Role.Value(
+                    self.config.MeshtasticReset.Role
+                )
+                device_cfg = node.localConfig.device
+                if device_cfg.role != role_enum:
+                    diffs.append(
+                        f'role {device_cfg.role}->{self.config.MeshtasticReset.Role}'
+                    )
+                    device_cfg.role = role_enum
+                    node.writeConfig('device')
+            except Exception as exc:  # pylint:disable=broad-except
+                self.logger.error('Invalid role %s: %s', self.config.MeshtasticReset.Role, repr(exc))
+
+        if hasattr(self.config.MeshtasticReset, 'MapReporting'):
+            try:
+                map_report = self.config.enforce_type(
+                    bool, self.config.MeshtasticReset.MapReporting
+                )
+                module_cfg = node.moduleConfig
+                if module_cfg.mqtt.map_reporting_enabled != map_report:
+                    diffs.append(
+                        f'map_reporting {module_cfg.mqtt.map_reporting_enabled}->{map_report}'
+                    )
+                    module_cfg.mqtt.map_reporting_enabled = map_report
+                    node.writeConfig('mqtt')
+            except Exception as exc:  # pylint:disable=broad-except
+                self.logger.error('Failed to set map reporting: %s', repr(exc))
+
+        for diff in diffs:
+            self.logger.info('Reset parameter: %s', diff)
 
     def on_mqtt_node(self, node_id, payload):
         """


### PR DESCRIPTION
## Summary
- move reset-related options to new `[MeshtasticReset]` section
- update device parameter reset code to use the new configuration
- default long name uses the Telegram room link
- update default short name, role, duty cycle and map reporting values

## Testing
- `make lint`
- `make mypy`


------
https://chatgpt.com/codex/tasks/task_e_68457c915480832483521634734d2b36