### PR TITLE
Add low battery alert to Telegram

### DIFF
--- a/mesh.ini.example
+++ b/mesh.ini.example
@@ -109,6 +109,8 @@ DatabaseFile = meshtastic.sqlite
 # pt: Registrar informações do nó no arquivo
 NodeLogEnabled = false
 NodeLogFile = /tmp/node_log.csv
+LowBatteryAlertEnabled = false
+LowBatteryThreshold = 10
 FIFOEnabled = false
 WelcomeMessage = Welcome to our community
 WelcomeMessageEnabled = false


### PR DESCRIPTION
## Summary
- notify Telegram on low battery events with configurable threshold

## Testing
- `make test`
- `make lint`
- `make mypy`


------
https://chatgpt.com/codex/tasks/task_e_684585c85fb48324b9bc7e4ac4ac2c68