### PR TITLE
Improve low battery notification handling

### DIFF
--- a/mtg/bot/meshtastic/meshtastic.py
+++ b/mtg/bot/meshtastic/meshtastic.py
@@ -54,6 +54,8 @@ class MeshtasticBot:  # pylint:disable=too-many-instance-attributes
         # cache
         self.memcache = Memcache(self.logger)
         self.memcache.run_noblock()
+        # cache of last battery readings per node to avoid duplicates
+        self.battery_cache = {}
 
     def set_aprs(self, aprs):
         """
@@ -352,12 +354,37 @@ class MeshtasticBot:  # pylint:disable=too-many-instance-attributes
                                                                                self.config.Telegram.NotificationsRoom),
                                               text=f"New node: {msg}")
 
-    def notify_low_battery(self, node_id: str, battery: int, interface: meshtastic_serial_interface.SerialInterface) -> None:
+    def _battery_emoji(self, level: int) -> str:
+        """Return an emoji representing battery state."""
+        if level is None:
+            return "❓"
+        if level >= 80:
+            return "🟢"
+        if level >= 50:
+            return "🟡"
+        if level >= 20:
+            return "🟠"
+        return "🔴"
+
+    def notify_low_battery(
+        self,
+        node_id: str,
+        battery: int,
+        interface: meshtastic_serial_interface.SerialInterface,
+        rx_time: float,
+    ) -> None:
         """Send a Telegram message if battery level is below configured threshold."""
         if not self.config.enforce_type(bool, self.config.Meshtastic.LowBatteryAlertEnabled):
             return
         threshold = self.config.enforce_type(int, self.config.Meshtastic.LowBatteryThreshold)
-        if battery is None or battery >= threshold:
+        if battery is None:
+            return
+        # ignore outdated packets
+        if rx_time < self.meshtastic_connection.get_startup_ts:
+            return
+        last_level = self.battery_cache.get(node_id)
+        self.battery_cache[node_id] = battery
+        if battery >= threshold or (last_level is not None and battery >= last_level):
             return
         node_name = node_id
         node_info = interface.nodes.get(node_id)
@@ -368,9 +395,10 @@ class MeshtasticBot:  # pylint:disable=too-many-instance-attributes
             found, record = self.database.get_node_record(node_id)
             if found:
                 node_name = record.nodeName
+        emoji = self._battery_emoji(battery)
         self.telegram_connection.send_message(
             chat_id=self.config.enforce_type(int, self.config.Telegram.Room),
-            text=f"{node_name}: battery at {battery}%, needs charging",
+            text=f"Battery {emoji} {battery}% for {node_name}",
         )
 
     # pylint:disable=too-many-branches, too-many-statements, too-many-return-statements
@@ -415,7 +443,7 @@ class MeshtasticBot:  # pylint:disable=too-many-instance-attributes
 
                 # Low battery alert from position updates
                 battery = decoded.get('position', {}).get('batteryLevel')
-                self.notify_low_battery(from_id, battery, interface)
+                self.notify_low_battery(from_id, battery, interface, packet.get('rxTime', 0))
 
                 # Send Meshtastic node coordinates to APRS for licenced operators
                 if self.aprs is not None and from_id is not None:
@@ -427,7 +455,7 @@ class MeshtasticBot:  # pylint:disable=too-many-instance-attributes
                 return
             if decoded.get('portnum') == 'TELEMETRY_APP':
                 battery = decoded.get('telemetry', {}).get('deviceMetrics', {}).get('batteryLevel')
-                self.notify_low_battery(from_id, battery, interface)
+                self.notify_low_battery(from_id, battery, interface, packet.get('rxTime', 0))
                 return
             return
         # get msg


### PR DESCRIPTION
## Summary
- track last battery readings to avoid repeated alerts
- skip outdated packets when checking battery state
- add emoji-based battery display

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6845a26da2808324989eca830f03e75e