### PR TITLE
Ensure Meshtastic reset enforces MQTT defaults

### DIFF
--- a/mesh.ini.example
+++ b/mesh.ini.example
@@ -136,6 +136,10 @@ DutyCycle = true
 Role = ROUTER_LATE
 # Allow sharing location over MQTT public maps. Boolean.
 MapReporting = true
+# Allow the radio to publish to MQTT brokers. Boolean.
+OkToMQTT = true
+# Ignore incoming MQTT updates. Boolean.
+IgnoreMQTT = false
 
 [APRS]
 # en: APRS functionality. Not actually used. Boolean.

--- a/mtg/connection/meshtastic/meshtastic.py
+++ b/mtg/connection/meshtastic/meshtastic.py
@@ -243,6 +243,22 @@ class MeshtasticConnection:
                 diffs.append(f'duty_cycle {lora.override_duty_cycle}->{duty}')
                 lora.override_duty_cycle = duty
                 lora_changed = True
+        ok_to_mqtt = getattr(self.config.MeshtasticReset, 'OkToMQTT', None)
+        if ok_to_mqtt is not None:
+            ok_to_mqtt = self.config.enforce_type(bool, ok_to_mqtt)
+            if lora.config_ok_to_mqtt != ok_to_mqtt:
+                diffs.append(
+                    f'ok_to_mqtt {lora.config_ok_to_mqtt}->{ok_to_mqtt}'
+                )
+                lora.config_ok_to_mqtt = ok_to_mqtt
+                lora_changed = True
+        ignore_mqtt = getattr(self.config.MeshtasticReset, 'IgnoreMQTT', None)
+        if ignore_mqtt is not None:
+            ignore_mqtt = self.config.enforce_type(bool, ignore_mqtt)
+            if lora.ignore_mqtt != ignore_mqtt:
+                diffs.append(f'ignore_mqtt {lora.ignore_mqtt}->{ignore_mqtt}')
+                lora.ignore_mqtt = ignore_mqtt
+                lora_changed = True
         if lora_changed:
             node.writeConfig('lora')
 


### PR DESCRIPTION
## Summary
- ensure the Meshtastic reset routine can toggle the radio's MQTT allow/ignore settings
- document the new defaults in the example configuration file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ae03ba4c83249246ac92f58c7b92