### PR TITLE
Broaden legacy table migration detection

### DIFF
--- a/mtg/database/sqlite.py
+++ b/mtg/database/sqlite.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+import sqlite3
 import time
 #
 from datetime import datetime, timedelta
@@ -111,14 +112,14 @@ class MessageLinkRecord(DB.Entity):  # pylint:disable=too-few-public-methods
     id = PrimaryKey(int, auto=True)
     direction = Required(str)
     status = Required(str)
-    telegram_chat_id = Optional(int)
-    telegram_message_id = Optional(int)
-    telegram_thread_id = Optional(int)
-    meshtastic_packet_id = Optional(int)
+    telegram_chat_id = Optional(int, size=64)
+    telegram_message_id = Optional(int, size=64)
+    telegram_thread_id = Optional(int, size=64)
+    meshtastic_packet_id = Optional(int, size=64)
     payload = Optional(str)
     sender = Optional(str)
-    reply_to_packet_id = Optional(int)
-    emoji = Optional(int)
+    reply_to_packet_id = Optional(int, size=64)
+    emoji = Optional(int, size=64)
     retries = Required(int)
     last_error = Optional(str)
     created_at = Required(datetime)
@@ -131,8 +132,8 @@ class MessageLinkAlias(DB.Entity):  # pylint:disable=too-few-public-methods
 
     id = PrimaryKey(int, auto=True)
     link = Required(MessageLinkRecord)
-    meshtastic_packet_id = Required(int, unique=True)
-    previous_packet_id = Optional(int)
+    meshtastic_packet_id = Required(int, unique=True, size=64)
+    previous_packet_id = Optional(int, size=64)
 
 
 class MeshtasticDB:
@@ -143,8 +144,228 @@ class MeshtasticDB:
     def __init__(self, db_file: AnyStr, logger: logging.Logger):
         self.connection = None
         self.logger = logger
+        self.db_file = db_file
+        if DB.provider is not None:
+            DB.disconnect()
+            DB.provider = None
+            DB.schema = None
         DB.bind(provider='sqlite', filename=db_file, create_db=True)
+        migration_state = self._run_migrations(db_file)
         DB.generate_mapping(create_tables=True)
+        self._finalize_migrations(db_file, migration_state)
+
+    @staticmethod
+    def _run_migrations(db_file: AnyStr) -> dict[str, bool]:
+        """Run pre-mapping migrations and return their execution state."""
+
+        migration_state = {
+            'message_link_resized': False,
+            'message_link_alias_resized': False,
+            'message_link_old_table': None,
+            'message_link_alias_old_table': None,
+        }
+
+        try:
+            conn = sqlite3.connect(db_file)
+        except sqlite3.Error:
+            return migration_state
+
+        with conn:
+            table_name, schema_sql = MeshtasticDB._locate_table(
+                conn,
+                (
+                    'MessageLinkRecord',
+                    'message_link_record',
+                    'messagelinkrecord',
+                ),
+            )
+            if table_name and schema_sql:
+                if MeshtasticDB._schema_has_32bit_constraint(
+                    schema_sql,
+                    (
+                        'telegram_chat_id',
+                        'telegram_message_id',
+                        'telegram_thread_id',
+                        'meshtastic_packet_id',
+                        'reply_to_packet_id',
+                        'emoji',
+                    ),
+                ):
+                    conn.execute('PRAGMA foreign_keys=OFF')
+                    old_table_name = f'{table_name}_old'
+                    conn.execute(
+                        f'ALTER TABLE "{table_name}" RENAME TO "{old_table_name}"',
+                    )
+                    migration_state['message_link_resized'] = True
+                    migration_state['message_link_old_table'] = old_table_name
+
+            table_name, schema_sql = MeshtasticDB._locate_table(
+                conn,
+                (
+                    'MessageLinkAlias',
+                    'message_link_alias',
+                    'messagelinkalias',
+                ),
+            )
+            if table_name and schema_sql:
+                if MeshtasticDB._schema_has_32bit_constraint(
+                    schema_sql,
+                    (
+                        'meshtastic_packet_id',
+                        'previous_packet_id',
+                    ),
+                ):
+                    if not migration_state['message_link_resized']:
+                        conn.execute('PRAGMA foreign_keys=OFF')
+                    conn.execute('DROP INDEX IF EXISTS idx_MessageLinkAlias__link')
+                    conn.execute('DROP INDEX IF EXISTS idx_MessageLinkAlias_link')
+                    conn.execute('DROP INDEX IF EXISTS idx_messagelinkalias__link')
+                    conn.execute('DROP INDEX IF EXISTS idx_messagelinkalias_link')
+                    conn.execute('DROP INDEX IF EXISTS messagelinkalias_link_idx')
+                    old_table_name = f'{table_name}_old'
+                    conn.execute(
+                        f'ALTER TABLE "{table_name}" RENAME TO "{old_table_name}"',
+                    )
+                    migration_state['message_link_alias_resized'] = True
+                    migration_state['message_link_alias_old_table'] = old_table_name
+
+            if migration_state['message_link_resized'] or migration_state['message_link_alias_resized']:
+                conn.execute('PRAGMA foreign_keys=ON')
+
+        conn.close()
+        return migration_state
+
+    @staticmethod
+    def _schema_has_32bit_constraint(schema_sql: str, columns: Iterable[str]) -> bool:
+        """Return True if any of the given columns enforce 32-bit bounds."""
+
+        if not schema_sql:
+            return False
+        for column in columns:
+            constraint_fragment = f'"{column}" BETWEEN -2147483648 AND 2147483647'
+            if constraint_fragment in schema_sql:
+                return True
+        return False
+
+    @staticmethod
+    def _finalize_migrations(db_file: AnyStr, migration_state: dict[str, bool]) -> None:
+        """Copy data into freshly generated tables after migrations."""
+
+        if not (
+            migration_state.get('message_link_resized')
+            or migration_state.get('message_link_alias_resized')
+        ):
+            return
+
+        try:
+            conn = sqlite3.connect(db_file)
+        except sqlite3.Error:
+            return
+
+        try:
+            conn.execute('PRAGMA foreign_keys=OFF')
+            if migration_state.get('message_link_resized'):
+                old_table = migration_state.get('message_link_old_table')
+                if old_table:
+                    new_table = MeshtasticDB._entity_table_name(
+                        MessageLinkRecord,
+                        'MessageLinkRecord',
+                    )
+                    conn.execute(
+                        f'''
+                        INSERT INTO "{new_table}" (
+                            id,
+                            direction,
+                            status,
+                            telegram_chat_id,
+                            telegram_message_id,
+                            telegram_thread_id,
+                            meshtastic_packet_id,
+                            payload,
+                            sender,
+                            reply_to_packet_id,
+                            emoji,
+                            retries,
+                            last_error,
+                            created_at,
+                            updated_at
+                        )
+                        SELECT
+                            id,
+                            direction,
+                            status,
+                            telegram_chat_id,
+                            telegram_message_id,
+                            telegram_thread_id,
+                            meshtastic_packet_id,
+                            COALESCE(payload, ''),
+                            COALESCE(sender, ''),
+                            reply_to_packet_id,
+                            emoji,
+                            retries,
+                            COALESCE(last_error, ''),
+                            created_at,
+                            updated_at
+                        FROM "{old_table}"
+                        ''',
+                    )
+                    conn.execute(f'DROP TABLE IF EXISTS "{old_table}"')
+            if migration_state.get('message_link_alias_resized'):
+                old_table = migration_state.get('message_link_alias_old_table')
+                if old_table:
+                    new_table = MeshtasticDB._entity_table_name(
+                        MessageLinkAlias,
+                        'MessageLinkAlias',
+                    )
+                    conn.execute(
+                        f'''
+                        INSERT INTO "{new_table}" (
+                            id,
+                            link,
+                            meshtastic_packet_id,
+                            previous_packet_id
+                        )
+                        SELECT
+                            id,
+                            link,
+                            meshtastic_packet_id,
+                            previous_packet_id
+                        FROM "{old_table}"
+                        ''',
+                    )
+                    conn.execute(f'DROP TABLE IF EXISTS "{old_table}"')
+            conn.execute('PRAGMA foreign_keys=ON')
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _normalize_identifier(identifier: str) -> str:
+        """Return a simplified identifier that eases case and style comparisons."""
+
+        return re.sub(r"[^a-z0-9]", "", identifier.lower())
+
+    @staticmethod
+    def _locate_table(conn: sqlite3.Connection, candidates: Iterable[str]):
+        normalized_candidates = {
+            MeshtasticDB._normalize_identifier(candidate): candidate
+            for candidate in candidates
+        }
+        cursor = conn.execute("SELECT name, sql FROM sqlite_master WHERE type='table'")
+        for name, schema_sql in cursor.fetchall():
+            if not schema_sql:
+                continue
+            simplified = MeshtasticDB._normalize_identifier(name)
+            if simplified in normalized_candidates:
+                return name, schema_sql
+        return None, None
+
+    @staticmethod
+    def _entity_table_name(entity, default_name: str) -> str:
+        table = getattr(entity, '_table_', None)
+        if table is not None and hasattr(table, 'name'):
+            return table.name
+        return default_name
 
     def set_meshtastic(self, connection) -> None:
         """

--- a/tests/test_message_linking.py
+++ b/tests/test_message_linking.py
@@ -1,5 +1,7 @@
 import logging
+import sqlite3
 import sys
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -67,6 +69,219 @@ def clean_db(meshtastic_db):  # pylint:disable=redefined-outer-name
     yield
 
 
+def _create_legacy_message_link_tables(db_path: Path, *, lowercase: bool = False) -> None:
+    record_table = "messagelinkrecord" if lowercase else "MessageLinkRecord"
+    alias_table = "messagelinkalias" if lowercase else "MessageLinkAlias"
+    index_name = (
+        "idx_messagelinkalias_link" if lowercase else "idx_MessageLinkAlias__link"
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            '''
+            CREATE TABLE "{record_table}" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+                "direction" TEXT NOT NULL,
+                "status" TEXT NOT NULL,
+                "telegram_chat_id" INTEGER CHECK("telegram_chat_id" BETWEEN -2147483648 AND 2147483647),
+                "telegram_message_id" INTEGER CHECK("telegram_message_id" BETWEEN -2147483648 AND 2147483647),
+                "telegram_thread_id" INTEGER CHECK("telegram_thread_id" BETWEEN -2147483648 AND 2147483647),
+                "meshtastic_packet_id" INTEGER,
+                "payload" TEXT,
+                "sender" TEXT,
+                "reply_to_packet_id" INTEGER CHECK("reply_to_packet_id" BETWEEN -2147483648 AND 2147483647),
+                "emoji" INTEGER CHECK("emoji" BETWEEN -2147483648 AND 2147483647),
+                "retries" INTEGER NOT NULL,
+                "last_error" TEXT,
+                "created_at" DATETIME NOT NULL,
+                "updated_at" DATETIME NOT NULL
+            );
+
+            CREATE TABLE "{alias_table}" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+                "link" INTEGER NOT NULL,
+                "meshtastic_packet_id" INTEGER NOT NULL UNIQUE,
+                "previous_packet_id" INTEGER CHECK("previous_packet_id" BETWEEN -2147483648 AND 2147483647),
+                FOREIGN KEY("link") REFERENCES "{record_table}"("id") ON DELETE CASCADE
+            );
+
+            CREATE INDEX "{index_name}"
+            ON "{alias_table}" ("link");
+            '''.format(record_table=record_table, alias_table=alias_table, index_name=index_name)
+        )
+
+
+def test_existing_database_with_32bit_constraints_is_migrated(tmp_path, meshtastic_db):
+    original_db_path = Path(meshtastic_db.db_file)
+    db_path = tmp_path / "legacy.sqlite"
+    _create_legacy_message_link_tables(db_path)
+
+    try:
+        created_at = datetime.utcnow().isoformat()
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                '''
+            INSERT INTO MessageLinkRecord (
+                direction,
+                status,
+                telegram_chat_id,
+                telegram_message_id,
+                meshtastic_packet_id,
+                    payload,
+                    sender,
+                    retries,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    MESSAGE_DIRECTION_TELEGRAM_TO_MESH,
+                    'pending',
+                    100,
+                    200,
+                    300,
+                    'legacy payload',
+                    'LegacyUser',
+                    1,
+                    created_at,
+                    created_at,
+                ),
+            )
+            conn.execute(
+                '''
+            INSERT INTO MessageLinkAlias (
+                link,
+                meshtastic_packet_id,
+                previous_packet_id
+            ) VALUES (?, ?, ?)
+            ''',
+                (1, 400, 300),
+            )
+
+        migrated_db = MeshtasticDB(str(db_path), logging.getLogger("test"))
+
+        with db_session:
+            legacy = MessageLinkRecord.get(id=1)
+            assert legacy is not None
+            assert legacy.telegram_chat_id == 100
+            alias = MessageLinkAlias.get(id=1)
+            assert alias is not None
+            assert alias.previous_packet_id == 300
+
+        large_chat_id = -1002310528626
+        record = migrated_db.ensure_message_link(
+            direction=MESSAGE_DIRECTION_TELEGRAM_TO_MESH,
+            telegram_chat_id=large_chat_id,
+            telegram_message_id=14170,
+            payload="Test",
+            sender="Komяpa",
+        )
+
+        with db_session:
+            refreshed = MessageLinkRecord[record.id]
+            assert refreshed.telegram_chat_id == large_chat_id
+
+        with sqlite3.connect(db_path) as conn:
+            schema_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                ('MessageLinkRecord',),
+            ).fetchone()[0]
+            alias_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+                ('MessageLinkAlias',),
+            ).fetchone()[0]
+
+        assert '2147483647' not in schema_sql
+        assert '2147483647' not in alias_sql
+    finally:
+        MeshtasticDB(str(original_db_path), logging.getLogger("test"))
+
+
+def test_lowercase_legacy_table_names_are_migrated(tmp_path, meshtastic_db):
+    original_db_path = Path(meshtastic_db.db_file)
+    db_path = tmp_path / "legacy-lower.sqlite"
+    _create_legacy_message_link_tables(db_path, lowercase=True)
+
+    try:
+        created_at = datetime.utcnow().isoformat()
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                '''
+            INSERT INTO messagelinkrecord (
+                direction,
+                status,
+                telegram_chat_id,
+                telegram_message_id,
+                meshtastic_packet_id,
+                    payload,
+                    sender,
+                    retries,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    MESSAGE_DIRECTION_TELEGRAM_TO_MESH,
+                    'pending',
+                    100,
+                    200,
+                    300,
+                    'legacy payload',
+                    'LegacyUser',
+                    1,
+                    created_at,
+                    created_at,
+                ),
+            )
+            conn.execute(
+                '''
+            INSERT INTO messagelinkalias (
+                link,
+                meshtastic_packet_id,
+                previous_packet_id
+            ) VALUES (?, ?, ?)
+            ''',
+                (1, 400, 300),
+            )
+
+        migrated_db = MeshtasticDB(str(db_path), logging.getLogger("test"))
+
+        large_chat_id = -1002310528626
+        record = migrated_db.ensure_message_link(
+            direction=MESSAGE_DIRECTION_TELEGRAM_TO_MESH,
+            telegram_chat_id=large_chat_id,
+            telegram_message_id=14170,
+            payload="Test",
+            sender="Komяpa",
+        )
+
+        with db_session:
+            refreshed = MessageLinkRecord[record.id]
+            assert refreshed.telegram_chat_id == large_chat_id
+
+        with sqlite3.connect(db_path) as conn:
+            schema_map = {
+                name.lower(): sql
+                for name, sql in conn.execute(
+                    "SELECT name, sql FROM sqlite_master WHERE type='table'"
+                )
+                if sql
+            }
+
+        record_schema = schema_map.get('messagelinkrecord') or schema_map.get(
+            'messagelink_record'
+        )
+        alias_schema = schema_map.get('messagelinkalias') or schema_map.get(
+            'messagelink_alias'
+        )
+
+        assert record_schema is not None
+        assert alias_schema is not None
+        assert '2147483647' not in record_schema
+        assert '2147483647' not in alias_schema
+    finally:
+        MeshtasticDB(str(original_db_path), logging.getLogger("test"))
+
+
 def test_send_user_text_multipart_chain():
     connection = MeshtasticConnection("test", logging.getLogger("test"), None, None)
     fake_interface = FakeInterface()
@@ -112,3 +327,18 @@ def test_reply_lookup_for_multipart_chain(meshtastic_db):  # pylint:disable=rede
         alias = MessageLinkAlias.get(meshtastic_packet_id=202)
         assert alias is not None
         assert alias.previous_packet_id == 201
+
+
+def test_large_telegram_chat_id_is_accepted(meshtastic_db):  # pylint:disable=redefined-outer-name
+    large_chat_id = -1002310528626
+    record = meshtastic_db.ensure_message_link(
+        direction=MESSAGE_DIRECTION_TELEGRAM_TO_MESH,
+        telegram_chat_id=large_chat_id,
+        telegram_message_id=14170,
+        payload="Test",
+        sender="Komяpa",
+    )
+
+    with db_session:
+        refreshed = MessageLinkRecord[record.id]
+        assert refreshed.telegram_chat_id == large_chat_id


### PR DESCRIPTION
## Summary
- detect legacy message link tables even when they use lowercase CamelCase-less names and clean up more historical indexes during migration
- add a regression test that verifies databases with lowercase message link tables migrate cleanly and accept large Telegram identifiers

## Testing
- pytest tests/test_message_linking.py

------
https://chatgpt.com/codex/tasks/task_e_6909cd14281c8324b216ea6e2cdecd2c